### PR TITLE
Input fixed rescaling

### DIFF
--- a/Trainer/vit.py
+++ b/Trainer/vit.py
@@ -172,8 +172,8 @@ class MaskGIT(Trainer):
         for x, y in bar:
             x = x.to(self.args.device)
             y = y.to(self.args.device)
-            x = 2 * x - 1 # normalize from x in [0,1] to [-1,1] for VQGAN 
-            
+            x = 2 * x - 1 # normalize from x in [0,1] to [-1,1] for VQGAN
+
             # Drop xx% of the condition for cfg
             drop_label = torch.empty(y.size()).uniform_(0, 1) < self.args.drop_label
 

--- a/Trainer/vit.py
+++ b/Trainer/vit.py
@@ -172,8 +172,8 @@ class MaskGIT(Trainer):
         for x, y in bar:
             x = x.to(self.args.device)
             y = y.to(self.args.device)
-            x = 2 * (x - x.min()) / (x.max() - x.min()) - 1    # VQGAN take normalized img
-
+            x = 2 * x - 1 # normalize from x in [0,1] to [-1,1] for VQGAN 
+            
             # Drop xx% of the condition for cfg
             drop_label = torch.empty(y.size()).uniform_(0, 1) < self.args.drop_label
 


### PR DESCRIPTION
VQGAN takes inputs in [-1, 1]
Previously, the rescaling was adaptive, using min and max values in the batch, so that it handles any format returned by the dataloader. But the behavior is not reliable as 0 and 255 pixel values are not always reached in the batch, especially when batch size is small. We now suppose the dataloader provide images normalized between [0,1] and use a fixed rescaling.